### PR TITLE
Flexible storage

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": false
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Function `Random::replace_candidate()` is slightly faster
+- The cache now accepts additional template arguments to change the underlying map for retrieving cache items.
 
 ### Removed
 - Removed Catch2 submodule

--- a/include/Cache/Cache.h
+++ b/include/Cache/Cache.h
@@ -41,17 +41,16 @@ struct NullLock
 };
 
 template<
-	typename Key,                                            // Key type
-	typename Value,                                          // Value type
-	template<typename> class CachePolicy = Policy::Random,   // Cache policy
-	typename Lock = NullLock,                                // Lock type (for multithreading)
-	template<typename...> class StatsProvider = Stats::Basic // Statistics measurement object
+	typename Key,                                                // Key type
+	typename Value,                                              // Value type
+	template<typename> class CachePolicy = Policy::Random,       // Cache policy
+	typename Lock = NullLock,                                    // Lock type (for multithreading)
+	template<typename...> class StatsProvider = Stats::Basic,    // Statistics measurement object
+	typename underlying_storage = std::unordered_map<Key, Value> // Underlying map used for cache lookup
 >
 class Cache
 {
 private:
-	using underlying_storage = std::unordered_map<Key, Value>;
-
 	const size_t m_MaxSize;
 	underlying_storage m_Cache;
 	mutable CachePolicy<Key> m_CachePolicy;


### PR DESCRIPTION
**Changes**:
- Allows selecting a different map type upon creating the Cache (e.g., `boost::unordered_flat_map`). The default behavior is to use `std::unordered_map` as before. Future versions might place constraints on the template argument.